### PR TITLE
fix: removing sanitize-html when saving anotation content

### DIFF
--- a/public/js/editor/editor.view.js
+++ b/public/js/editor/editor.view.js
@@ -29,7 +29,7 @@ export class editorView{
 
         let paragraphEl = document.createElement('p');
 
-        paragraphEl.innerText = content;
+        paragraphEl.textContent = content;
 
         paragraphEl.classList.add('editor-paragraph');
 

--- a/services/notes.service.js
+++ b/services/notes.service.js
@@ -41,9 +41,9 @@ export async function createNoteService(userId, title, parentId, icon, emoji, im
 
         //console.log('zod validated Data: ', validation.data);
 
-        const sanitized = sanitizeNote(validation.data);
+        //const sanitized = sanitizeNote(validation.data);
 
-        const {id: testedId, title: testedTitle, parentId: testedParentId, icon: testedIcon, emoji: testedEmoji, image: testedImage, content: testedContent, favorite: testedFavorite} = sanitized;
+        const {id: testedId, title: testedTitle, parentId: testedParentId, icon: testedIcon, emoji: testedEmoji, image: testedImage, content: testedContent, favorite: testedFavorite} = validation.data;
 
         const searchContent = getText(testedContent);
 
@@ -118,9 +118,9 @@ export async function updateNoteService(
 
         //console.log('zod validated Data: ', validation.data);
         
-        const sanitized = sanitizeNote(validation.data);
+        //const sanitized = sanitizeNote(validation.data);
 
-        const {id: testedId, title: testedTitle, parentId: testedParentId, icon: testedIcon, emoji: testedEmoji, image: testedImage, content: testedContent, favorite: testedFavorite} = sanitized;
+        const {id: testedId, title: testedTitle, parentId: testedParentId, icon: testedIcon, emoji: testedEmoji, image: testedImage, content: testedContent, favorite: testedFavorite} = validation.data;
 
         const searchContent = getText(testedContent);
 

--- a/todo.md
+++ b/todo.md
@@ -14,7 +14,7 @@
 - [ ] Change bcrypt to Argon to prevent GPU-Accelerated dictionary attack
 - [x] When saving images, use UUID to change their names, otherwise there may be name conflicts in the database.
 - [x] When saving notes content, save a text version of content in search_content
-- [ ] Fix sanitization issue! When users type: <script>alert()</script>, the database saves: script alert script. This is incorrect because users are saving plain text, not HTML. The original text should be preserved. 
+- [x] Fix sanitization issue! When users type: <script>alert()</script>, the database saves: script alert script. This is incorrect because users are saving plain text, not HTML. The original text should be preserved. 
 
 # Customization Tasks List:
 


### PR DESCRIPTION
## Description

Removing sanitize html to fix the next issue: When users type <script>alert()</script>, the sanitize-html saves: "". This is incorrect because users are saving plain text. The original text should be preserved.

## Type of Change:
- [x] Bug Fix

## How Has This Been Tested? (If needed)

Manual Testing.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have tested my changes
- [x] I have updated the documentation (If needed)
